### PR TITLE
Ensure the text value is centered when unit is null

### DIFF
--- a/lib/src/circle_progress_bar/animated_double_count.dart
+++ b/lib/src/circle_progress_bar/animated_double_count.dart
@@ -71,6 +71,8 @@ class _AnimatedCountState extends State<AnimatedCount>
       builder: (BuildContext context, Widget? child) {
         return Row(
           mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: widget.unit != null ? MainAxisAlignment.start : MainAxisAlignment.center,
+          crossAxisAlignment: widget.unit != null ? CrossAxisAlignment.start : CrossAxisAlignment.center,
           children: [
             Text(
               _animation.value


### PR DESCRIPTION
When no unit is set the text values shows uncentered, like showed below:

```
CircleProgressBar(
            foregroundColor: foregroundColor,
            backgroundColor: backgroundColor,
            value: 0.5,
            strokeWidth: 2,
            reversedDirection: true,
            child: AnimatedCount(
              count: 20,
              fractionDigits: 0,
              unit: null,
              duration: Duration(milliseconds: 500),
              style: textStyle,
            ),
          )
```

![image](https://user-images.githubusercontent.com/2206761/192567802-84cb8a23-11fc-48a4-85f2-0e25b25efae4.png)

This PRs intends to ensure that the Row Aligns its axis to the center when unit is null.

![image](https://user-images.githubusercontent.com/2206761/192568591-f7dcf70c-6af2-4abe-b95c-445464cd6a31.png)

